### PR TITLE
Detect USB ports

### DIFF
--- a/src/bash_scripts/detect_usb_devices.sh
+++ b/src/bash_scripts/detect_usb_devices.sh
@@ -25,3 +25,14 @@ for sysdevpath in $(find /sys/bus/usb/devices/usb*/ -name dev); do
 		fi
 	)
 done
+
+while IFS= read -r line
+do
+	echo "$line"
+	arr=($line)
+	echo ${arr[0]}
+	echo ${arr[1]}
+	export ${arr[0]}=${arr[1]}
+done < "$DEV_TO_PORT_FILE"
+
+echo $ARDUINO_PORT

--- a/src/bash_scripts/detect_usb_devices.sh
+++ b/src/bash_scripts/detect_usb_devices.sh
@@ -15,17 +15,13 @@ for sysdevpath in $(find /sys/bus/usb/devices/usb*/ -name dev); do
 		echo "/dev/$devname - $ID_SERIAL"
 
 		if [[ "$ID_SERIAL" == *"Arduino"* || "$ID_SERIAL" == *"1a86_USB2.0"* ]]; then
-			echo "arduino /dev/$devname" >> $DEV_TO_PORT_FILE
-			export ARDUINO_PORT="/dev/$devname"
+			echo "ARDUINO_PORT /dev/$devname" >> $DEV_TO_PORT_FILE
 		elif [[ "$ID_SERIAL" == *"Basic_UART"* ]]; then
-			echo "antenna /dev/$devname" >> $DEV_TO_PORT_FILE
-			export ANTENNA_PORT="/dev/$devname"
+			echo "ANTENNA_PORT /dev/$devname" >> $DEV_TO_PORT_FILE
 		elif [[ "$ID_SERIAL" == *"Silicon_Labs"* ]]; then
-			echo "lidar /dev/$devname" >> $DEV_TO_PORT_FILE
-			export LIDAR_PORT="/dev/$devname"
+			echo "LIDAR_PORT /dev/$devname" >> $DEV_TO_PORT_FILE
 		elif [[ "$devname" == *"video"* ]]; then
-			echo "camera /dev/$devname" >> $DEV_TO_PORT_FILE
-			export CAMERA_PORT="/dev/$devname"
+			echo "CAMERA_PORT /dev/$devname" >> $DEV_TO_PORT_FILE
 		fi
 	)
 done

--- a/src/bash_scripts/detect_usb_devices.sh
+++ b/src/bash_scripts/detect_usb_devices.sh
@@ -2,6 +2,9 @@
 
 DEV_TO_PORT_FILE="dev_to_port.txt"
 
+# clear file contents
+> $DEV_TO_PORT_FILE
+
 for sysdevpath in $(find /sys/bus/usb/devices/usb*/ -name dev); do
 	(
 		syspath="${sysdevpath%/dev}"
@@ -10,20 +13,19 @@ for sysdevpath in $(find /sys/bus/usb/devices/usb*/ -name dev); do
 		eval "$(udevadm info -q property --export -p $syspath)"
 		[[ -z "$ID_SERIAL" ]] && exit
 		echo "/dev/$devname - $ID_SERIAL"
-		echo $ID_SERIAL
-		[[$ID_SERIAL == *'Arduino'*]] && is_arduino=true || is_arduino=false
-		[[grep -q "Arduino" <<< $ID_SERIAL]] && is_arduino=true || is_arduino=false
 
-		echo $is_arduino
-
-		if [["$ID_SERIAL" == *"Arduino"*]] || [[$ID_SERIAL == *"arduino"*]] || [[$devname == *"ACM"* ]]
-		then
-			echo "ARDUINO"
+		if [[ "$ID_SERIAL" == *"Arduino"* || "$ID_SERIAL" == *"1a86_USB2.0"* ]]; then
+			echo "arduino /dev/$devname" >> $DEV_TO_PORT_FILE
+			export ARDUINO_PORT="/dev/$devname"
+		elif [[ "$ID_SERIAL" == *"Basic_UART"* ]]; then
+			echo "antenna /dev/$devname" >> $DEV_TO_PORT_FILE
+			export ANTENNA_PORT="/dev/$devname"
+		elif [[ "$ID_SERIAL" == *"Silicon_Labs"* ]]; then
+			echo "lidar /dev/$devname" >> $DEV_TO_PORT_FILE
+			export LIDAR_PORT="/dev/$devname"
+		elif [[ "$devname" == *"video"* ]]; then
+			echo "camera /dev/$devname" >> $DEV_TO_PORT_FILE
+			export CAMERA_PORT="/dev/$devname"
 		fi
-
-		if [["$ID_SERIAL" =~ "Arduino" ]]
-		then
-			echo "arduino is here"
-		fi 
 	)
 done

--- a/src/bash_scripts/detect_usb_devices.sh
+++ b/src/bash_scripts/detect_usb_devices.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+DEV_TO_PORT_FILE="dev_to_port.txt"
+
+for sysdevpath in $(find /sys/bus/usb/devices/usb*/ -name dev); do
+	(
+		syspath="${sysdevpath%/dev}"
+		devname="$(udevadm info -q name -p $syspath)"
+		[[ "$devname" == "bus/"* ]] && exit
+		eval "$(udevadm info -q property --export -p $syspath)"
+		[[ -z "$ID_SERIAL" ]] && exit
+		echo "/dev/$devname - $ID_SERIAL"
+		echo $ID_SERIAL
+		[[$ID_SERIAL == *'Arduino'*]] && is_arduino=true || is_arduino=false
+		[[grep -q "Arduino" <<< $ID_SERIAL]] && is_arduino=true || is_arduino=false
+
+		echo $is_arduino
+
+		if [["$ID_SERIAL" == *"Arduino"*]] || [[$ID_SERIAL == *"arduino"*]] || [[$devname == *"ACM"* ]]
+		then
+			echo "ARDUINO"
+		fi
+
+		if [["$ID_SERIAL" =~ "Arduino" ]]
+		then
+			echo "arduino is here"
+		fi 
+	)
+done

--- a/src/bash_scripts/dev_to_port.txt
+++ b/src/bash_scripts/dev_to_port.txt
@@ -1,0 +1,2 @@
+arduino /dev/ttyACM0
+antenna /dev/ttyUSB0

--- a/src/bash_scripts/dev_to_port.txt
+++ b/src/bash_scripts/dev_to_port.txt
@@ -1,2 +1,2 @@
-arduino /dev/ttyACM0
-antenna /dev/ttyUSB0
+ARDUINO_PORT /dev/ttyACM0
+ANTENNA_PORT /dev/ttyUSB0


### PR DESCRIPTION
Bash script that detects the /dev/* names of all the connected USB devices and exports the following environment variables: 

ANTENNA_PORT
ARDUINO_PORT
CAMERA_PORT
LIDAR_PORT

Will still need to be sourced in setup.sh