### PR TITLE
Fix chair receiver dying. SAVE THIS as steady-state (ish) of code

### DIFF
--- a/src/antenna/scripts/chair_receiver.py
+++ b/src/antenna/scripts/chair_receiver.py
@@ -23,7 +23,7 @@ def chair_receiver():
 
     while not rospy.is_shutdown():
         str_msg = ser.readline().strip()
-        if len(str_msg >= 2):
+        if len(str_msg) >= 2:
             rospy.loginfo(str_msg)
             debug_pub.publish(str_msg)
             if str_msg[0] == chair_num or str_msg[0] == "0":

--- a/src/antenna/scripts/chair_receiver.py
+++ b/src/antenna/scripts/chair_receiver.py
@@ -4,14 +4,15 @@ import rospy
 import serial
 from std_msgs.msg import String
 
-antenna_port = rospy.get_param('antenna_port')
-chair_num = rospy.get_param('chair_num')
+antenna_port = rospy.get_param("antenna_port")
+chair_num = rospy.get_param("chair_num")
 ser = serial.Serial(antenna_port, 57600)
 
 
 def close_serial():
     rospy.logerr("SHUTTING DOWN ANTENNA RECEIVER")
     ser.close()
+
 
 def chair_receiver():
     pub = rospy.Publisher("from_chair_receiver", String, queue_size=10)
@@ -22,13 +23,14 @@ def chair_receiver():
 
     while not rospy.is_shutdown():
         str_msg = ser.readline().strip()
-        rospy.loginfo(str_msg)
-        debug_pub.publish(str_msg)
-        if str_msg[0] == chair_num or str_msg[0] == "0":
-            pub.publish(str_msg[1:])
+        if len(str_msg >= 2):
+            rospy.loginfo(str_msg)
+            debug_pub.publish(str_msg)
+            if str_msg[0] == chair_num or str_msg[0] == "0":
+                pub.publish(str_msg[1:])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     try:
         chair_receiver()
     except rospy.ROSInterruptException as err:

--- a/src/antenna/src/chair_manager.cpp
+++ b/src/antenna/src/chair_manager.cpp
@@ -59,7 +59,7 @@ const std::unordered_map<std::string, Command> cmd_to_case = {
 char LAUNCH_AUTONOMOUS_SCRIPT[] = "~/anon_auton_ws/src/launch_manager/launch/launch_autonomous.sh &";
 char LAUNCH_HANDWRITTEN_SCRIPT[] = "~/anon_auton_ws/src/launch_manager/launch/launch_handwritten.sh &";
 char SHUTDOWN_SCRIPT[] = "~/anon_auton_ws/src/launch_manager/launch/shutdown.sh &";
-char RESET_SCRIPT[] = "source ~/.bashrc; killros; chair";
+char RESET_SCRIPT[] = "~/anon_auton_ws/src/launch_manager/launch/reset.sh &";
 
 // probably not necessary
 // #define NUMBER_OF_CHAIRS 1

--- a/src/antenna/src/chair_manager.cpp
+++ b/src/antenna/src/chair_manager.cpp
@@ -59,7 +59,7 @@ const std::unordered_map<std::string, Command> cmd_to_case = {
 char LAUNCH_AUTONOMOUS_SCRIPT[] = "~/anon_auton_ws/src/launch_manager/launch/launch_autonomous.sh &";
 char LAUNCH_HANDWRITTEN_SCRIPT[] = "~/anon_auton_ws/src/launch_manager/launch/launch_handwritten.sh &";
 char SHUTDOWN_SCRIPT[] = "~/anon_auton_ws/src/launch_manager/launch/shutdown.sh &";
-char RESET_SCRIPT[] = "killros; chair";
+char RESET_SCRIPT[] = "source ~/.bashrc; killros; chair";
 
 // probably not necessary
 // #define NUMBER_OF_CHAIRS 1

--- a/src/antenna/src/chair_manager.cpp
+++ b/src/antenna/src/chair_manager.cpp
@@ -59,7 +59,7 @@ const std::unordered_map<std::string, Command> cmd_to_case = {
 char LAUNCH_AUTONOMOUS_SCRIPT[] = "~/anon_auton_ws/src/launch_manager/launch/launch_autonomous.sh &";
 char LAUNCH_HANDWRITTEN_SCRIPT[] = "~/anon_auton_ws/src/launch_manager/launch/launch_handwritten.sh &";
 char SHUTDOWN_SCRIPT[] = "~/anon_auton_ws/src/launch_manager/launch/shutdown.sh &";
-char RESET_SCRIPT[] = "~/anon_auton_ws/src/launch_manager/launch/shutdown.sh &";
+char RESET_SCRIPT[] = "killros; chair";
 
 // probably not necessary
 // #define NUMBER_OF_CHAIRS 1

--- a/src/antenna/src/hub_manager.cpp
+++ b/src/antenna/src/hub_manager.cpp
@@ -277,12 +277,6 @@ void broadcast_callback(const std_msgs::String &msg)
 std::string notReadyChairsToString()
 {
 	std::string response = "";
-	for (auto s : chair_status_map)
-}
-
-std::string notReadyChairsToString()
-{
-	std::string response = "";
 	for (const auto &p : chair_status_map)
 	{
 		if (p.second.cbs != chair_broadcast_status::ready && p.second.cbs != chair_broadcast_status::exclude)

--- a/src/antenna/src/hub_manager.cpp
+++ b/src/antenna/src/hub_manager.cpp
@@ -290,6 +290,7 @@ std::string notReadyChairsToString()
 void alertGui(std::string custom_msg)
 {
 	std_msgs::String msg;
+	ROS_ERROR("alert gui: %s", custom_msg);
 	msg.data = "A CHAIR NEEDS HELP!\n" + custom_msg;
 	hub_to_gui_pub.publish(msg);
 }

--- a/src/antenna/src/hub_manager.cpp
+++ b/src/antenna/src/hub_manager.cpp
@@ -281,7 +281,7 @@ std::string notReadyChairsToString()
 	{
 		if (p.second.cbs != chair_broadcast_status::ready && p.second.cbs != chair_broadcast_status::exclude)
 		{
-			response += p.first;
+			response += ('0' + p.first);
 		}
 	}
 	return response;
@@ -290,8 +290,8 @@ std::string notReadyChairsToString()
 void alertGui(std::string custom_msg)
 {
 	std_msgs::String msg;
-	ROS_ERROR("alert gui: %s", custom_msg);
-	msg.data = "A CHAIR NEEDS HELP!\n" + custom_msg;
+	ROS_ERROR("alert gui: %s", custom_msg.c_str());
+	msg.data = "A CHAIR NEEDS HELP!\n" + custom_msg.c_str();
 	hub_to_gui_pub.publish(msg);
 }
 

--- a/src/antenna/src/hub_manager.cpp
+++ b/src/antenna/src/hub_manager.cpp
@@ -291,7 +291,7 @@ void alertGui(std::string custom_msg)
 {
 	std_msgs::String msg;
 	ROS_ERROR("alert gui: %s", custom_msg.c_str());
-	msg.data = "A CHAIR NEEDS HELP!\n" + custom_msg.c_str();
+	msg.data = "A CHAIR NEEDS HELP!\n" + custom_msg;
 	hub_to_gui_pub.publish(msg);
 }
 

--- a/src/antenna/src/hub_manager.cpp
+++ b/src/antenna/src/hub_manager.cpp
@@ -274,10 +274,29 @@ void broadcast_callback(const std_msgs::String &msg)
 	}
 }
 
-void alertGui()
+std::string notReadyChairsToString()
+{
+	std::string response = "";
+	for (auto s : chair_status_map)
+}
+
+std::string notReadyChairsToString()
+{
+	std::string response = "";
+	for (const auto &p : chair_status_map)
+	{
+		if (p.second.cbs != chair_broadcast_status::ready && p.second.cbs != chair_broadcast_status::exclude)
+		{
+			response += p.first;
+		}
+	}
+	return response;
+}
+
+void alertGui(std::string custom_msg)
 {
 	std_msgs::String msg;
-	msg.data = "A CHAIR NEEDS HELP!";
+	msg.data = "A CHAIR NEEDS HELP!\n" + custom_msg;
 	hub_to_gui_pub.publish(msg);
 }
 
@@ -371,7 +390,7 @@ int main(int argc, char **argv)
 				if (timesChecked >= timesCheckedLimit)
 				{
 					timesChecked = 0;
-					alertGui();
+					alertGui(notReadyChairsToString());
 					clean_up_after_broadcast_done();
 				}
 				break;

--- a/src/eyes/src/queue_five.cpp
+++ b/src/eyes/src/queue_five.cpp
@@ -310,7 +310,7 @@ int main(int argc, char **argv)
 	mode = state::autonomous;
 	while (ros::ok())
 	{
-		ROS_ERROR("\nflag_A: %s\t\tflag_B: %s\t\tflag_C: %s\t\tflag_H: %s\nflag_T: %s\t\tflag_D: %s\t\tflag_S: %s\nflag_EOC: %s\tflag_SOB: %s\tflag_EOB: %s", BoolToString(flag_A), BoolToString(flag_B), BoolToString(flag_C), BoolToString(flag_H), BoolToString(flag_T), BoolToString(flag_D), BoolToString(flag_S), BoolToString(flag_EOC), BoolToString(flag_SOB), BoolToString(flag_EOB));
+		ROS_ERROR("\nflag_A:\t%s\tflag_B:\t%s\tflag_C:\t%s\tflag_H:\t%s\nflag_T:\t%s\tflag_D:\t%s\tflag_S:\t%s\nflag_EOC:\t%s\tflag_SOB:\t%s\tflag_EOB:\t%s", BoolToString(flag_A), BoolToString(flag_B), BoolToString(flag_C), BoolToString(flag_H), BoolToString(flag_T), BoolToString(flag_D), BoolToString(flag_S), BoolToString(flag_EOC), BoolToString(flag_SOB), BoolToString(flag_EOB));
 		// ROS_ERROR("ROS OK");
 		switch (mode)
 		{

--- a/src/eyes/src/queue_five.cpp
+++ b/src/eyes/src/queue_five.cpp
@@ -310,7 +310,7 @@ int main(int argc, char **argv)
 	mode = state::autonomous;
 	while (ros::ok())
 	{
-		ROS_ERROR("\nflag_A:\t%s\tflag_B:\t%s\tflag_C:\t%s\tflag_H:\t%s\nflag_T:\t%s\tflag_D:\t%s\tflag_S:\t%s\nflag_EOC:\t%s\tflag_SOB:\t%s\tflag_EOB:\t%s", BoolToString(flag_A), BoolToString(flag_B), BoolToString(flag_C), BoolToString(flag_H), BoolToString(flag_T), BoolToString(flag_D), BoolToString(flag_S), BoolToString(flag_EOC), BoolToString(flag_SOB), BoolToString(flag_EOB));
+		ROS_ERROR("\nflag_A:\t\t%s\tflag_B:\t\t%s\tflag_C:\t\t%s\tflag_H:\t\t%s\nflag_T:\t\t%s\tflag_D:\t\t%s\tflag_S:\t\t%s\nflag_EOC:\t%s\tflag_SOB:\t%s\tflag_EOB:\t%s", BoolToString(flag_A), BoolToString(flag_B), BoolToString(flag_C), BoolToString(flag_H), BoolToString(flag_T), BoolToString(flag_D), BoolToString(flag_S), BoolToString(flag_EOC), BoolToString(flag_SOB), BoolToString(flag_EOB));
 		// ROS_ERROR("ROS OK");
 		switch (mode)
 		{

--- a/src/eyes/src/queue_five.cpp
+++ b/src/eyes/src/queue_five.cpp
@@ -539,7 +539,7 @@ int main(int argc, char **argv)
 				autonomous_queue = std::queue<eyes::Generic>();
 				choreo_queue = std::queue<eyes::Generic>();
 				custom_queue = std::queue<eyes::Generic>();
-				broadcast_queue = std::queue<eyes::Generic>();
+				// broadcast_queue = std::queue<eyes::Generic>();
 				// tell camera to publish to me
 				std_msgs::Empty empty_msg;
 				eoc_pub.publish(empty_msg);

--- a/src/eyes/src/queue_five.cpp
+++ b/src/eyes/src/queue_five.cpp
@@ -540,6 +540,9 @@ int main(int argc, char **argv)
 				choreo_queue = std::queue<eyes::Generic>();
 				custom_queue = std::queue<eyes::Generic>();
 				broadcast_queue = std::queue<eyes::Generic>();
+				// tell camera to publish to me
+				std_msgs::Empty empty_msg;
+				eoc_pub.publish(empty_msg);
 				ROS_ERROR("TOGGLE");
 				flag_SOB = false;
 				flag_EOB = false;

--- a/src/eyes/src/queue_five.cpp
+++ b/src/eyes/src/queue_five.cpp
@@ -539,7 +539,7 @@ int main(int argc, char **argv)
 				autonomous_queue = std::queue<eyes::Generic>();
 				choreo_queue = std::queue<eyes::Generic>();
 				custom_queue = std::queue<eyes::Generic>();
-				// broadcast_queue = std::queue<eyes::Generic>();
+				broadcast_queue = std::queue<eyes::Generic>();
 				// tell camera to publish to me
 				std_msgs::Empty empty_msg;
 				eoc_pub.publish(empty_msg);

--- a/src/eyes/src/queue_five.cpp
+++ b/src/eyes/src/queue_five.cpp
@@ -541,8 +541,8 @@ int main(int argc, char **argv)
 				custom_queue = std::queue<eyes::Generic>();
 				broadcast_queue = std::queue<eyes::Generic>();
 				// tell camera to publish to me
-				std_msgs::Empty empty_msg;
-				eoc_pub.publish(empty_msg);
+				// std_msgs::Empty empty_msg;
+				// eoc_pub.publish(empty_msg);
 				ROS_ERROR("TOGGLE");
 				flag_SOB = false;
 				flag_EOB = false;

--- a/src/eyes/src/queue_five.cpp
+++ b/src/eyes/src/queue_five.cpp
@@ -358,11 +358,11 @@ int main(int argc, char **argv)
 			notify_lidar.publish(queue_to_lidar_msg);
 			if (flag_T)
 			{
-				ROS_ERROR("IN CHOREO with Flag T");
+				// ROS_ERROR("IN CHOREO with Flag T");
 			}
 			if (flag_H)
 			{
-				ROS_ERROR("IN CHOREO with Flag H");
+				// ROS_ERROR("IN CHOREO with Flag H");
 			}
 
 			if (flag_H)

--- a/src/eyes/src/queue_five.cpp
+++ b/src/eyes/src/queue_five.cpp
@@ -284,6 +284,11 @@ ros::Publisher update_hub_pub;
 ros::Publisher audio_pub;
 ros::Publisher notify_lidar;
 
+inline const char *const BoolToString(bool b)
+{
+	return b ? "true" : "false";
+}
+
 int main(int argc, char **argv)
 {
 	ros::init(argc, argv, "queue_five");
@@ -305,6 +310,7 @@ int main(int argc, char **argv)
 	mode = state::autonomous;
 	while (ros::ok())
 	{
+		ROS_ERROR("flag_A: %s\tflag_B\t%s\tflag_C: %s\tflag_H: %s\nflag_T: %s\tflag_D: %s\tflag_S: %s\nflag_EOC: %s\tflag_SOB: %s\tflag_EOB: %s", BoolToString(flag_A), BoolToString(flag_B), BoolToString(flag_C), BoolToString(flag_H), BoolToString(flag_T), BoolToString(flag_D), BoolToString(flag_S), BoolToString(flag_EOC), BoolToString(flag_SOB), BoolToString(flag_EOB));
 		// ROS_ERROR("ROS OK");
 		switch (mode)
 		{

--- a/src/eyes/src/queue_five.cpp
+++ b/src/eyes/src/queue_five.cpp
@@ -310,7 +310,7 @@ int main(int argc, char **argv)
 	mode = state::autonomous;
 	while (ros::ok())
 	{
-		ROS_ERROR("flag_A: %s\tflag_B\t%s\tflag_C: %s\tflag_H: %s\nflag_T: %s\tflag_D: %s\tflag_S: %s\nflag_EOC: %s\tflag_SOB: %s\tflag_EOB: %s", BoolToString(flag_A), BoolToString(flag_B), BoolToString(flag_C), BoolToString(flag_H), BoolToString(flag_T), BoolToString(flag_D), BoolToString(flag_S), BoolToString(flag_EOC), BoolToString(flag_SOB), BoolToString(flag_EOB));
+		ROS_ERROR("\nflag_A: %s\t\tflag_B: %s\t\tflag_C: %s\t\tflag_H: %s\nflag_T: %s\t\tflag_D: %s\t\tflag_S: %s\nflag_EOC: %s\tflag_SOB: %s\tflag_EOB: %s", BoolToString(flag_A), BoolToString(flag_B), BoolToString(flag_C), BoolToString(flag_H), BoolToString(flag_T), BoolToString(flag_D), BoolToString(flag_S), BoolToString(flag_EOC), BoolToString(flag_SOB), BoolToString(flag_EOB));
 		// ROS_ERROR("ROS OK");
 		switch (mode)
 		{

--- a/src/launch_manager/launch/reset.sh
+++ b/src/launch_manager/launch/reset.sh
@@ -10,4 +10,4 @@ echo "stop" > /tmp/handwritten-input
 
 sleep 5 
 
-./src/launch_manager/launch/launch_antenna_chair.sh &
+./src/launch_manager/scripts/chair_on_startup.bash &

--- a/src/robot_gui_bridge/gui/gui.html
+++ b/src/robot_gui_bridge/gui/gui.html
@@ -228,7 +228,7 @@
         updateChairStatus(element, status);
       }
 
-      function updateChairBroadcastStatus(key, status) {
+      function updateBroadcastStatus(key, status) {
         let element = document.getElementById(key + "_broadcast_status");
         if (element) {
           element.innerHTML = getTextForStatus(status);

--- a/src/robot_gui_bridge/gui/gui.html
+++ b/src/robot_gui_bridge/gui/gui.html
@@ -190,16 +190,24 @@
       });
 
       getTextForStatus = function (status) {
-        if (status == "r") {
+        if (status == "Br") {
           return "READY";
         } else if (status == "h") {
           return "HEARTBEAT";
-        } else if (status == "e") {
+        } else if (status == "Be") {
           return "EXCLUDE";
-        } else if (status == "s") {
+        } else if (status == "Bs") {
           return "SUCCESS";
-        } else if (status == "f") {
+        } else if (status == "Bf") {
           return "FAILURE";
+        } else if (status == "Tt") {
+          return "TRAPPED";
+        } else if (status == "Tm") {
+          return "NOT TRAPPED";
+        } else if (status == "Ss") {
+          return "STUCK";
+        } else if (status == "Sn") {
+          return "NOT STUCK";
         } else if (status == "o" || status == null) {
           return "OFFLINE";
         } else {
@@ -207,10 +215,41 @@
         }
       };
 
-      function updateChairStatus(key, status) {
-        let element = document.getElementById(key + "status");
+      function updateChairStatus(element, status) {
         if (element) {
           element.innerHTML = getTextForStatus(status);
+          element.classList.remove(...element.classList);
+          element.classList.add("status", status);
+        }
+      }
+
+      function updateHeartbeatStatus(key, status) {
+        let element = document.getElementById(key + "status");
+        updateChairStatus(element, status);
+      }
+
+      function updateChairBroadcastStatus(key, status) {
+        let element = document.getElementById(key + "_broadcast_status");
+        if (element) {
+          element.innerHTML = getTextForStatus(status);
+          element.classList.remove(...element.classList);
+          element.classList.add("status", status);
+        }
+      }
+
+      function updateChairTrappedStatus(key, status) {
+        let element = document.getElementById(key + "_trapped_status");
+        if (element) {
+          element.innerHTML = getTextForStatus(status);
+          element.classList.remove(...element.classList);
+          element.classList.add("status", status);
+        }
+      }
+
+      function updateChairStuckStatus(key, status) {
+        let element = document.getElementById(key + "_stuck_status");
+        if (element) {
+          element.innerHTML = getTextForStuckStatus(status);
           element.classList.remove(...element.classList);
           element.classList.add("status", status);
         }
@@ -231,14 +270,14 @@
           m.data[1] == "B"
         ) {
           live_status.set(m.data[0], m.data[2]);
-          updateChairStatus(m.data[0], m.data[2]);
+          updateBroadcastStatus(m.data[0], m.data[1] + m.data[2]);
         } else if (
           // heartbeat
           m.data.length == 2 &&
           chairs.includes(m.data[0]) &&
           m.data[1] == "h"
         ) {
-          updateChairStatus(m.data[0], m.data[1]);
+          updateHeartbeatStatus(m.data[0], m.data[1]);
         }
         // image
         if (m.data[1] == "i") {
@@ -249,7 +288,7 @@
       function checkStatus() {
         for (let [key, value] of live_status) {
           if (value == null) {
-            updateChairStatus(key, "o");
+            updateHeartbeatStatus(key, "o");
           }
           live_status.set(key, null);
         }
@@ -1025,6 +1064,7 @@
         <div class="chair_monitor" id="1">
           <h2>Chair 1</h2>
           <div class="status o" id="1status">OFFLINE</div>
+          <div class="status o" id="1_broadcast_status">OFFLINE</div>
           <br />
           <div class="chair_control">
             <div class="directions">
@@ -1073,6 +1113,7 @@
         <div class="chair_monitor" id="2">
           <h2>Chair 2</h2>
           <div class="status o" id="2status">OFFLINE</div>
+          <div class="status o" id="2_broadcast_status">OFFLINE</div>
           <br />
           <div class="chair_control">
             <div class="directions">
@@ -1121,6 +1162,7 @@
         <div class="chair_monitor" id="3">
           <h2>Chair 3</h2>
           <div class="status o" id="3status">OFFLINE</div>
+          <div class="status o" id="3_broadcast_status">OFFLINE</div>
           <br />
           <div class="chair_control">
             <div class="directions">
@@ -1169,6 +1211,7 @@
         <div class="chair_monitor" id="4">
           <h2>Chair 4</h2>
           <div class="status o" id="4status">OFFLINE</div>
+          <div class="status o" id="4_broadcast_status">OFFLINE</div>
           <br />
           <div class="chair_control">
             <div class="directions">

--- a/src/robot_gui_bridge/gui/gui.html
+++ b/src/robot_gui_bridge/gui/gui.html
@@ -1063,7 +1063,9 @@
       <div class="statuses">
         <div class="chair_monitor" id="1">
           <h2>Chair 1</h2>
-          <div class="status o" id="1status">OFFLINE</div>
+          <div class="status o" id="1status">
+            OFFLINE<span class="dot"></span>
+          </div>
           <div class="status o" id="1_broadcast_status">OFFLINE</div>
           <br />
           <div class="chair_control">
@@ -1112,7 +1114,7 @@
         </div>
         <div class="chair_monitor" id="2">
           <h2>Chair 2</h2>
-          <div class="status o" id="2status">OFFLINE</div>
+          <div class="status o" id="2status">OFFLINE<span class="dot"></span></div>
           <div class="status o" id="2_broadcast_status">OFFLINE</div>
           <br />
           <div class="chair_control">
@@ -1161,7 +1163,7 @@
         </div>
         <div class="chair_monitor" id="3">
           <h2>Chair 3</h2>
-          <div class="status o" id="3status">OFFLINE</div>
+          <div class="status o" id="3status">OFFLINE<span class="dot"></span></div>
           <div class="status o" id="3_broadcast_status">OFFLINE</div>
           <br />
           <div class="chair_control">
@@ -1210,7 +1212,7 @@
         </div>
         <div class="chair_monitor" id="4">
           <h2>Chair 4</h2>
-          <div class="status o" id="4status">OFFLINE</div>
+          <div class="status o" id="4status">OFFLINE<span class="dot"></span></div>
           <div class="status o" id="4_broadcast_status">OFFLINE</div>
           <br />
           <div class="chair_control">

--- a/src/robot_gui_bridge/gui/index.css
+++ b/src/robot_gui_bridge/gui/index.css
@@ -171,3 +171,12 @@ textarea {
     display: flex; 
     flex-direction: column;
 }
+
+.dot {
+    height: 12px;
+    width: 12px;
+    background-color: limegreen;
+    border-radius: 50%;
+    display: inline-block;
+    margin-left: 5px;
+  }

--- a/src/robot_gui_bridge/gui/index.css
+++ b/src/robot_gui_bridge/gui/index.css
@@ -70,6 +70,22 @@
     background-color: greenyellow;
 }
 
+.Br {
+    background-color: mediumaquamarine;
+}
+
+.Be {
+    background-color: orange;
+}
+
+.Bs {
+    background-color: greenyellow;
+}
+
+.Bf {
+    background-color: red;
+}
+
 .f {
     background-color: red;
 }


### PR DESCRIPTION
Some bugs around interaction between handwritten, lidar, and broadcast. 

REPRO:
1. put all the chairs into handwritten (i.e., by hitting "STOP ALL" on hub)
2. run Test choreo = all exclude
_This won’t exit correctly_
3. run AUTO ALL
4. run Test choreo -- see that they are funky

Another bug: 
* If hub doesn't get success/failure from a chair, hub manager gets in a borked state. Need to clear the broadcast first. 
* Need to add some way of re-pulling the end state of the chair.

Need to have gui ask hub_manager for statuses of chairs rather than parsing statuses itself. 

Add a waiting stage for broadcast. And maybe also a running stage. 

Sometimes the chairs get kind of out of sync. 

Maybe have hub poll chairs for status every so often instead of just waiting for them to send. 