### PR TITLE
send eoc on startup of queue five

### DIFF
--- a/src/eyes/src/queue_five.cpp
+++ b/src/eyes/src/queue_five.cpp
@@ -333,6 +333,10 @@ int main(int argc, char **argv)
 	notify_lidar = nh.advertise<std_msgs::Char>("queue_to_lidar", 1000);
 	send_flags = nh.advertise<std_msgs::String>("queue_to_manager", 1000);
 
+	// Clear out if chair is somehow already in a choreo
+	ROS_ERROR("END OF CHOREO");
+	std_msgs::Empty empty_msg;
+	eoc_pub.publish(empty_msg);
 	// ros::Timer timer = nh.createTimer(ros::Duration(0.5), send_current_flags);
 
 	mode = state::autonomous;


### PR DESCRIPTION
Safety stop on the lidar seemed to not be working. What seemed to be happening: 
1. Chair started in an already stopped state (i.e., another chair or wall in front of it.)
2. `lidar` nodes launched and began calculating and emitting command suggestions.
3. Most of these were STOP, but once a certain time had passed
4. Command switched to ACD (choreo)
5. This was sent before the queue started. Thus the queue never knew to send end-of-choreo and tell the lidar to start listening again
6. Thus, the lidar was effectively not working

We now just send end-of-choreo on startup of the queue. 